### PR TITLE
Switch to Log4j logging and using logger for output exceptions

### DIFF
--- a/lib/openhab/log.py
+++ b/lib/openhab/log.py
@@ -4,7 +4,7 @@ import traceback
 
 from org.apache.logging.log4j import Logger, LogManager
 
-LOG_PREFIX = "org.eclipse.smarthome.automation.rules"
+LOG_PREFIX = "sboh2j"
 
 def log_traceback(fn):
     """Decorator to provide better Jython stack traces"""
@@ -16,7 +16,7 @@ def log_traceback(fn):
             if len(args) > 0 and hasattr(args[0], "log"):
                 args[0].log.error(traceback.format_exc())
             else:
-                logger = LogManager.getLogger("jython.scripting")
+                logger = LogManager.getLogger(LOG_PREFIX)
                 logger.error(traceback.format_exc())
             raise # Re-raise the exception (allowing a caller to see and handle the exception as well)
     return wrapper
@@ -26,7 +26,7 @@ class Log4j2Handler(logging.Handler):
         message = self.format(record)
         logger_name = record.name
         if record.name == "root":
-            logger = LogManager.getLogger("jython.scripting")
+            logger = LogManager.getLogger(LOG_PREFIX)
         else:
             logger = LogManager.getLogger(logger_name)
         level = record.levelno

--- a/lib/openhab/triggers.py
+++ b/lib/openhab/triggers.py
@@ -41,6 +41,7 @@ class ItemCommandTrigger(Trigger):
         Trigger.__init__(self, triggerName, "core.ItemCommandTrigger", Configuration(config))
 
 EVERY_SECOND = "0/1 * * * * ?"
+EVERY_10_SECONDS = "0/10 * * * * ?"
 EVERY_MINUTE = "0 * * * * ?"
 EVERY_HOUR = "0 0 * * * ?"
 
@@ -81,7 +82,7 @@ class ItemRegistryTrigger(OsgiEventTrigger):
 class ItemAddedTrigger(ItemRegistryTrigger):
     def __init__(self):
         ItemRegistryTrigger.__init__(self, "ItemAddedEvent")
-        
+
 class ItemRemovedTrigger(ItemRegistryTrigger):
      def __init__(self):
         ItemRegistryTrigger.__init__(self, "ItemRemovedEvent")
@@ -89,7 +90,7 @@ class ItemRemovedTrigger(ItemRegistryTrigger):
 class ItemUpdatedTrigger(ItemRegistryTrigger):
     def __init__(self):
         ItemRegistryTrigger.__init__(self, "ItemUpdatedEvent")
-        
+
 # Directory watcher trigger
 
 class DirectoryEventTrigger(Trigger):
@@ -109,13 +110,15 @@ class _FunctionRule(scope.SimpleRule):
         self.triggers = triggers
         self.callback = callback
         self.extended = extended
-        
+
     def execute(self, module, inputs):
         try:
             self.callback(module, inputs) if self.extended else self.callback()
         except:
             import traceback
-            print traceback.format_exc()
+            from openhab.log import logging
+            logging.error(traceback.format_exc())
+            raise # Re-raise the exception (allowing a caller to see and handle the exception as well)
 
 def time_triggered(cron_expression):
     def decorator(fn):


### PR DESCRIPTION
I've done various changes which involves switching from slf4j logging to Log4j. I've also made changes to how the error that gets caught in the exception clauses are put out. It will help a lot when using the Karaf console to monitor the log files in real time. 

The root log name has been changed from "" to "jython.scripting". Probably better to use the value from the constant `LOG_PREFIX = "org.eclipse.smarthome.automation.rules"` However it's so long so it will get truncated in the log.

Please review the suggested changes carefully if you consider to merge them. I'm a newbie and I make newbie mistakes. Thanks.